### PR TITLE
Corrected textInputStyle enum keys to match discords documentation

### DIFF
--- a/libs/enums.lua
+++ b/libs/enums.lua
@@ -1,8 +1,8 @@
 local enums = {}
 
 enums.textInputStyle = {
-  short = 1,
-  long  = 2,
+  short     = 1,
+  paragraph = 2,
 }
 
 return enums


### PR DESCRIPTION
ensure textInputStyle keys match names give in Discord documentation